### PR TITLE
Example Tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,4 +9,8 @@ organization := "org.apache.predictionio"
 libraryDependencies ++= Seq(
   "org.apache.predictionio" %% "apache-predictionio-core" % "0.10.0-incubating" % "provided",
   "org.apache.spark"        %% "spark-core"               % "1.3.0" % "provided",
-  "org.apache.spark"        %% "spark-mllib"              % "1.3.0" % "provided")
+  "org.apache.spark"        %% "spark-mllib"              % "1.3.0" % "provided",
+  "org.scalatest"           %% "scalatest"                % "2.2.1" % "test")
+
+// SparkContext is shared between all tests via SharedSingletonContext
+parallelExecution in Test := false

--- a/src/main/scala/Engine.scala
+++ b/src/main/scala/Engine.scala
@@ -1,13 +1,13 @@
 package org.template.vanilla
 
-import org.apache.predictionio.controller.IEngineFactory
+import org.apache.predictionio.controller.EngineFactory
 import org.apache.predictionio.controller.Engine
 
 case class Query(q: String) extends Serializable
 
 case class PredictedResult(p: String) extends Serializable
 
-object VanillaEngine extends IEngineFactory {
+object VanillaEngine extends EngineFactory {
   def apply() = {
     new Engine(
       classOf[DataSource],

--- a/src/test/scala/AlgorithmTest.scala
+++ b/src/test/scala/AlgorithmTest.scala
@@ -1,0 +1,26 @@
+package org.template.vanilla
+
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers
+
+import org.apache.predictionio.data.storage.Event
+
+class AlgorithmTest
+  extends FlatSpec with SharedSingletonContext with Matchers {
+
+  val params = AlgorithmParams(mult = 7)
+  val algorithm = new Algorithm(params)
+  val dataSource = Seq(
+    Event(event = "test", entityType = "example", entityId = "1"),
+    Event(event = "test", entityType = "example", entityId = "1"),
+    Event(event = "test", entityType = "example", entityId = "1"),
+    Event(event = "test", entityType = "example", entityId = "1"),
+    Event(event = "test", entityType = "example", entityId = "1"))
+
+  "train" should "return a model" in {
+    val dataSourceRDD = sparkContext.parallelize(dataSource)
+    val preparedData = new PreparedData(events = dataSourceRDD)
+    val model = algorithm.train(sparkContext, preparedData)
+    model shouldBe a [Model]
+  }
+}

--- a/src/test/scala/DataSourceTest.scala
+++ b/src/test/scala/DataSourceTest.scala
@@ -1,0 +1,15 @@
+package org.template.vanilla
+
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers
+
+class DataSourceTest
+  extends FlatSpec with SharedSingletonContext with Matchers {
+
+  ignore should "return the data" in {
+    val dataSource = new DataSource(
+      new DataSourceParams(appName = "test"))
+    val data = dataSource.readTraining(sc = sparkContext)
+    data shouldBe a [TrainingData]
+  }
+}

--- a/src/test/scala/EngineTest.scala
+++ b/src/test/scala/EngineTest.scala
@@ -1,0 +1,15 @@
+package org.template.vanilla
+
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers
+
+import org.apache.predictionio.controller.Engine
+
+class EngineTest
+  extends FlatSpec with Matchers {
+
+  "apply" should "return a new engine instance" in {
+    val engine = VanillaEngine.apply()
+    engine shouldBe an [Engine[_,_,_,_,_,_]]
+  }
+}

--- a/src/test/scala/PreparatorTest.scala
+++ b/src/test/scala/PreparatorTest.scala
@@ -1,0 +1,23 @@
+package org.template.vanilla
+
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers
+
+import org.apache.predictionio.data.storage.Event
+
+class PreparatorTest
+  extends FlatSpec with SharedSingletonContext with Matchers {
+
+  val dataSource = Seq(
+    Event(event = "test", entityType = "example", entityId = "1"),
+    Event(event = "test", entityType = "example", entityId = "1"),
+    Event(event = "test", entityType = "example", entityId = "1"),
+    Event(event = "test", entityType = "example", entityId = "1"),
+    Event(event = "test", entityType = "example", entityId = "1"))
+
+  "prepare" should "return the events" in {
+    val dataSourceRDD = sparkContext.parallelize(dataSource)
+    val preparedData = new PreparedData(events = dataSourceRDD)
+    preparedData shouldBe a [PreparedData]
+  }
+}

--- a/src/test/scala/ServingTest.scala
+++ b/src/test/scala/ServingTest.scala
@@ -1,0 +1,23 @@
+package org.template.vanilla
+
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers
+
+class ServingTest
+  extends FlatSpec with Matchers {
+
+  val query = Query(q = "5")
+  val predictedResults = Seq(
+    PredictedResult(p = "25"),
+    PredictedResult(p = "50"),
+    PredictedResult(p = "75"))
+
+  "serve" should "return the first prediction" in {
+    val serving = new Serving()
+    val prediction = serving.serve(
+      query = query,
+      predictedResults = predictedResults)
+    prediction shouldBe a [PredictedResult]
+    prediction.p shouldEqual "25"
+  }
+}

--- a/src/test/scala/SharedSingletonContext.scala
+++ b/src/test/scala/SharedSingletonContext.scala
@@ -1,0 +1,24 @@
+package org.template.vanilla
+
+import org.apache.spark.{SparkConf, SparkContext}
+import org.scalatest.{BeforeAndAfterAll, Suite}
+
+trait SharedSingletonContext extends BeforeAndAfterAll {
+  this: Suite =>
+
+  private var _sparkContext: Option[SparkContext] = None
+  def sparkContext = _sparkContext.get
+  val sparkConf = new SparkConf(false)
+
+  override def beforeAll() {
+    _sparkContext = Some(new SparkContext("local", "test", sparkConf))
+    super.beforeAll()
+  }
+
+  override def afterAll() {
+    super.afterAll()
+    sparkContext.stop()
+    _sparkContext = None
+    System.clearProperty("spark.driver.port")
+  }
+}


### PR DESCRIPTION
This skeleton repo seems to be the authoritative starting point for creating a new engine. Since testing is a great way to improve collaboration and reliability, what do you think about including example tests in the skeleton?

Here I implemented tests with a [ScalaTest](http://www.scalatest.org) suite which includes a mixin `SharedSingletonContext` to make a Spark context available as `SparkContext`.

Each of the engine-defined classes now has a tiny passing test: `AlgorithmTest`, `EngineTest`, `PreparatorTest`, & `ServingTest`.

`DataSourceTest` is the outlier and currently fails, so it's ignored. See progress in the comments.